### PR TITLE
Adicionando a lista de tasks atual no localStorage do navegador // Persist tasks state to localStorage

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,12 +7,26 @@ import Footer from "./components/Footer";
 import "./App.css";
 
 export default function App() {
-  const [tasks, setTasks] = useState([]);
+  // Lógica para carregar as tarefas do localStorage
+  const getInitialTasks = () => {
+    const storedTasks = localStorage.getItem('tasks');
+    // Se houver tarefas salvas, retorna elas. Se não, retorna um array vazio.
+    return storedTasks ? JSON.parse(storedTasks) : [];
+  };
+
+  // Usando a função getInitialTasks para inicializar o estado das tarefas
+  const [tasks, setTasks] = useState(getInitialTasks);
   const [filter, setFilter] = useState("all");
   const [theme, setTheme] = useState(() => {
     const savedTheme = localStorage.getItem('theme');
     return savedTheme ? savedTheme : 'light';
   });
+
+  // useEffect para salvar as tarefas no localStorage
+  // Este efeito é executado sempre que a variável 'tasks' muda
+  useEffect(() => {
+    localStorage.setItem('tasks', JSON.stringify(tasks));
+  }, [tasks]);
 
   useEffect(() => {
     localStorage.setItem('theme', theme);


### PR DESCRIPTION
Adicionei a logica de iniciar o aplicativo de task diretamente do localStorage e salvar novamente qualquer alteração para futuro acesso. // Added logic to initialize tasks from localStorage and save tasks to localStorage whenever they change. This ensures that tasks persist across page reloads.